### PR TITLE
Ajout de la traduction française du nom de Polybe (Issue #22) tlg0543

### DIFF
--- a/data/tlg0543/__cts__.xml
+++ b/data/tlg0543/__cts__.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" projid="greekLit:tlg0543" urn="urn:cts:greekLit:tlg0543">
         
-   <ti:groupname xml:lang="eng">Polybius.</ti:groupname>
+  	<ti:groupname xml:lang="eng">Polybius.</ti:groupname>
+	<ti:groupname xml:lang="fre">Polybe.</ti:groupname>
         
 </ti:textgroup>


### PR DESCRIPTION
La traduction française de Polybe a été ajoutée. 