### PR TITLE
(tlg0014/__cts__.xml)Ajout de la traduction française de Démosthène #21

### DIFF
--- a/data/tlg0014/__cts__.xml
+++ b/data/tlg0014/__cts__.xml
@@ -2,5 +2,7 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" projid="greekLit:tlg0014" urn="urn:cts:greekLit:tlg0014">
     
    <ti:groupname xml:lang="eng">Demosthenes</ti:groupname>
+   <ti:groupname xml:lang="fre">Démosthène</ti:groupname>
+   
     
 </ti:textgroup>


### PR DESCRIPTION
Ajout d'une traduction dans le fichier de métadonnée : https://github.com/PonteIneptique/canonical-greekLit/blob/master/data/tlg0014/__cts__.xml
